### PR TITLE
Use correct dot product for two vectors.

### DIFF
--- a/include/math/Vector.hpp
+++ b/include/math/Vector.hpp
@@ -167,7 +167,7 @@ namespace tnt
 
     inline constexpr float Dot(Vector const &lhs, Vector const &rhs) noexcept
     {
-        return lhs.x + rhs.x + lhs.y * rhs.y;
+        return lhs.x * rhs.x + lhs.y * rhs.y;
     }
 
     inline constexpr float Cross(Vector const &lhs, Vector const &rhs) noexcept


### PR DESCRIPTION
Fix error in Dot().